### PR TITLE
feat: introduce configuration for failfast flag

### DIFF
--- a/gotest.el
+++ b/gotest.el
@@ -45,6 +45,11 @@
   :type 'boolean
   :group 'gotest)
 
+(defcustom go-test-failfast nil
+  "Do not start new tests after the first test failure."
+  :type 'boolean
+  :group 'gotest)
+
 (defvar-local go-test-go-command nil
   "The 'go' command for 'go test' that should be used instead of `go-command'.
 
@@ -376,6 +381,8 @@ For example, if the current buffer is `foo.go', the buffer for
       (setq opts (s-concat go-test-args " " opts)))
     (when go-test-verbose
       (setq opts (s-concat "-v " opts)))
+    (when go-test-failfast
+      (setq opts (s-concat "-failfast " opts)))
     (go-test--get-arguments opts 'go-test-history)))
 
 

--- a/test/gotest-test.el
+++ b/test/gotest-test.el
@@ -77,6 +77,16 @@
        (should (string= (go-test-command "-v -race ")
                         (go-test--get-program (go-test--arguments ""))))))))
 
+(ert-deftest test-go-test-add-failfast-argument ()
+  :tags '(arguments current)
+  (with-test-sandbox
+   (let ((go-test-failfast t))
+     (should (string= (go-test-command "-failfast ")
+                      (go-test--get-program (go-test--arguments ""))))
+     (let ((go-test-args "-race"))
+       (should (string= (go-test-command "-failfast -race ")
+                        (go-test--get-program (go-test--arguments ""))))))))
+
 (ert-deftest test-go-run-command-without-args ()
   :tags '(arguments)
   (with-test-sandbox


### PR DESCRIPTION
Provides a way to failing tests fast when running with count.